### PR TITLE
bump: journal-gateway-zmtp -> 0.9.2

### DIFF
--- a/recipes-networking/journal-gateway-zmtp/journal-gateway-zmtp_1.0.0.bb
+++ b/recipes-networking/journal-gateway-zmtp/journal-gateway-zmtp_1.0.0.bb
@@ -5,15 +5,15 @@ DEPENDS += "czmq"
 DEPENDS += "jansson"
 DEPENDS += "systemd"
 LICENSE = "LGPL-2.1"
-PR = "r5"
+PR = "r1"
 
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL2.1;md5=4fbd65380cdd255951079008b364516c"
 
 inherit autotools systemd
 
-SRC_URI = "https://github.com/travelping/journal-gateway-zmtp/archive/v${PV}.tar.gz;downloadfilename=${PN}_v${PV}.tar.gz"
-SRC_URI[md5sum] = "38656f5682f66fb63b18c6d362297a79"
-SRC_URI[sha256sum] = "050814e13e39c0f3f87a8bceb4c4128ca094aff0b4d8af683e7e471244f8f433"
+SRC_URI = "https://github.com/travelping/journal-gateway-zmtp/archive/v${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz"
+SRC_URI[md5sum] = "098f006342145631711bcb1a2681f962"
+SRC_URI[sha256sum] = "dc62c0f12cda06049ac8f8f1ab74d66d633b11e4aa2911141d0a477dae13a1a6"
 
 S = "${WORKDIR}/${PN}-${PV}"
 
@@ -22,6 +22,7 @@ SYSTEMD_SERVICE_${PN} = "${PN}-sink.service"
 SYSTEMD_SERVICE_${PN} += "${PN}-source.service"
 
 do_compile() {
+    echo ${S}
     cd ${S}
     oe_runmake
 }
@@ -30,6 +31,7 @@ do_install() {
     install -d ${D}${bindir}
     install -m 0755 ${S}/journal-gateway-zmtp-source ${D}${bindir}
     install -m 0755 ${S}/journal-gateway-zmtp-sink ${D}${bindir}
+    install -m 0755 ${S}/journal-gateway-zmtp-control ${D}${bindir}
 
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${S}/misc/journal-gateway-zmtp-sink.service ${D}${systemd_unitdir}/system/.
@@ -40,7 +42,7 @@ do_install() {
     install -m 0644 ${S}/misc/journal-gateway-zmtp-source.conf ${D}${sysconfdir}/.
 }
 
-FILES_${PN} = "${bindir}/journal-gateway-zmtp-source ${bindir}/journal-gateway-zmtp-sink"
+FILES_${PN} = "${bindir}/journal-gateway-zmtp-source ${bindir}/journal-gateway-zmtp-sink ${bindir}/journal-gateway-zmtp-control"
 
 # systemd units
 FILES_${PN} += "${systemd_unitdir}/system/journal-gateway-zmtp-sink.service"


### PR DESCRIPTION
- bumped recipe for journal-gateway-zmtp (now uses commit-id's)
