### PR TITLE
Fix chown/chmod mixup in Bind recipe

### DIFF
--- a/recipes-connectivity/bind/bind/conf.patch
+++ b/recipes-connectivity/bind/bind/conf.patch
@@ -261,7 +261,7 @@ diff -urN bind-9.3.1.orig/init.d bind-9.3.1/init.d
 +	modprobe capability >/dev/null 2>&1 || true
 +	if [ ! -f /etc/bind/rndc.key ]; then
 +	    /usr/sbin/rndc-confgen -a -b 512 -r /dev/urandom
-+	    chown 0640 /etc/bind/rndc.key
++	    chmod 0640 /etc/bind/rndc.key
 +	fi
 +	if [ -f /var/run/named/named.pid ]; then
 +	    ps `cat /var/run/named/named.pid` > /dev/null && exit 1

--- a/recipes-connectivity/bind/bind/generate-rndc-key.sh
+++ b/recipes-connectivity/bind/bind/generate-rndc-key.sh
@@ -3,5 +3,5 @@
 if [ ! -s /etc/bind/rndc.key ]; then
     echo -n "Generating /etc/bind/rndc.key:"
     /usr/sbin/rndc-confgen -a -b 512 -r /dev/urandom
-    chown 0640 /etc/bind/rndc.key
+    chmod 0640 /etc/bind/rndc.key
 fi


### PR DESCRIPTION
```
modified:   recipes-connectivity/bind/bind/conf.patch
modified:   recipes-connectivity/bind/bind/generate-rndc-key.sh
```
