### PR TITLE
Iperf and Iperf3 no autostart

### DIFF
--- a/recipes-benchmark/iperf/iperf3_3.0.11.bb
+++ b/recipes-benchmark/iperf/iperf3_3.0.11.bb
@@ -4,7 +4,7 @@ SECTION = "console/network"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ab59a0c3a4bc3954d1ece68ea19d77a4"
 
-PR = "r1"
+PR = "r2"
 
 SRC_URI = "https://github.com/esnet/${PN}/archive/${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz \
            file://iperf3.service \
@@ -17,6 +17,7 @@ inherit autotools-brokensep systemd
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "iperf3.service"
+SYSTEMD_AUTO_ENABLE = "disable"
 
 S="${WORKDIR}/iperf-${PV}"
 

--- a/recipes-benchmark/iperf/iperf_2.0.5.bb
+++ b/recipes-benchmark/iperf/iperf_2.0.5.bb
@@ -4,7 +4,7 @@ SECTION = "console/network"
 LICENSE = "NewBSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e8478eae9f479e39bc34975193360298"
 
-PR = "1"
+PR = "2"
 
 SRC_URI = " \
 	${SOURCEFORGE_MIRROR}/iperf/iperf-${PV}.tar.gz \
@@ -27,6 +27,7 @@ inherit autotools systemd
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "iperf-tcp.service iperf-udp.service"
+SYSTEMD_AUTO_ENABLE = "disable"
 
 S="${WORKDIR}/iperf-${PV}"
 


### PR DESCRIPTION
Disable the iperf and iperf3 services by default after the installation.
