### PR TITLE
change dropbear config to use only strong crypto

### DIFF
--- a/recipes-core/dropbear/dropbear/use-only-strong-crypto-config.patch
+++ b/recipes-core/dropbear/dropbear/use-only-strong-crypto-config.patch
@@ -1,0 +1,36 @@
+diff -up dropbear-2014.63/options.h.orig dropbear-2014.63/options.h
+--- dropbear-2014.63/options.h.orig	2015-10-05 10:48:33.194227914 +0200
++++ dropbear-2014.63/options.h	2015-10-05 11:00:58.349566811 +0200
+@@ -91,12 +91,12 @@ much traffic. */
+  * Including multiple keysize variants the same cipher 
+  * (eg AES256 as well as AES128) will result in a minimal size increase.*/
+ #define DROPBEAR_AES128
+-#define DROPBEAR_3DES
++/*#define DROPBEAR_3DES*/
+ #define DROPBEAR_AES256
+ /* Compiling in Blowfish will add ~6kB to runtime heap memory usage */
+ /*#define DROPBEAR_BLOWFISH*/
+-#define DROPBEAR_TWOFISH256
+-#define DROPBEAR_TWOFISH128
++/*#define DROPBEAR_TWOFISH256*/
++/*#define DROPBEAR_TWOFISH128*/
+ 
+ /* Enable "Counter Mode" for ciphers. This is more secure than normal
+  * CBC mode against certain attacks. This adds around 1kB to binary 
+@@ -121,11 +121,11 @@ much traffic. */
+  * These hashes are also used for public key fingerprints in logs.
+  * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
+  * which are not the standard form. */
+-#define DROPBEAR_SHA1_HMAC
+-#define DROPBEAR_SHA1_96_HMAC
+-/*#define DROPBEAR_SHA2_256_HMAC*/
+-/*#define DROPBEAR_SHA2_512_HMAC*/
+-#define DROPBEAR_MD5_HMAC
++/*#define DROPBEAR_SHA1_HMAC*/
++/*#define DROPBEAR_SHA1_96_HMAC*/
++#define DROPBEAR_SHA2_256_HMAC
++#define DROPBEAR_SHA2_512_HMAC
++/*#define DROPBEAR_MD5_HMAC*/
+ 
+ /* You can also disable integrity. Don't bother disabling this if you're
+  * still using a cipher, it's relatively cheap. If you disable this it's dead

--- a/recipes-core/dropbear/dropbear_2014.66.bbappend
+++ b/recipes-core/dropbear/dropbear_2014.66.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'file://disable-x11fwd.patch', d)}"
+SRC_URI += "use-only-strong-crypto-config.patch \
+	    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'file://disable-x11fwd.patch', d)}"


### PR DESCRIPTION
- disable md5, sha1, sha1-96, twofish, blowfish and 3des
- enable sha2

This will lead to the following ssh MACs and ciphers:

Ciphers:       aes128-ctr, aes256-ctr, aes128-cbc, aes256-cbc
KexAlgorithms: curve25519-sha256@libssh.org, ecdh-sha2-nistp521, ecdh-sha2-nistp384, ecdh-sha2-nistp256, diffie-hellman-group1-sha1, diffie-hellman-group14-sha1
MACs           hmac-sha2-256, hmac-sha2-512
