### PR TITLE
prevent CAROS Apps/Services (mix.bbclass) to be automatically started/stopped/restarted

### DIFF
--- a/classes/caros-service.bbclass
+++ b/classes/caros-service.bbclass
@@ -1,0 +1,21 @@
+inherit systemd
+
+PACKAGESPLITFUNCS_prepend = "carossrv_populate_packages "
+
+# this basically undoes systemd.bbclass' service-controlling
+# postinst+prerm, by "defusing" systemctl executable
+python carossrv_populate_packages() {
+    pkg = d.getVar('PN', True)
+
+    postinst = d.getVar('pkg_postinst_%s' % pkg, True)
+    if not postinst:
+        postinst = '#!/bin/sh\n'
+    postinst += "#!/bin/sh\n# no-op\nsystemctl() {\necho defused: systemctl \"$@\"\n}\n"
+    d.setVar('pkg_postinst_%s'%pkg, postinst)
+
+    prerm = d.getVar('pkg_prerm_%s' % pkg, True)
+    if not prerm:
+        prerm = '#!/bin/sh\n'
+    prerm += "#!/bin/sh\n# no-op\nsystemctl() {\necho defused: systemctl \"$@\"\n}\n"
+    d.setVar('pkg_prerm_%s'%pkg, prerm)
+}

--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -40,7 +40,7 @@ CONFFILES_${PN} += "${SYSCONFIG_PREFIX}/${APPNAME}.conf"
 
 DEPENDS += "avahi erlang-lager-journald-backend elixir-native elixir rebar-native"
 
-inherit systemd
+inherit caros-service
 
 SYSTEMD_UNIT_NAME ?= "${APPNAME}"
 SYSTEMD_AUTO_ENABLE ?= "disable"


### PR DESCRIPTION
- defuses systemd.bbclass' systemctl calls
- updates mix.class to use caros-service instead of systemd
