### PR TITLE
mix-class: remove inner tar (relx) from package

### DIFF
--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -147,6 +147,7 @@ do_compile() {
 }
 
 do_install() {
+# TODO: rename TAR_DIR
     if [ -e rel/${REL_NAME}/releases/${REL_VSN}/${REL_NAME}.tar.gz ]
     then
         TAR_DIR="rel/${REL_NAME}/releases/${REL_VSN}/${REL_NAME}.tar.gz"
@@ -162,7 +163,7 @@ do_install() {
 
     install -m 0755 -d "${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION}/"
     tar xvz -C ${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION} -f $TAR_DIR
-    # TODO: maybe delete tar file (^^^^^^^) to reduce by 50% ipk size?
+    rm -vf ${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION}/releases/${REL_VSN}/${REL_NAME}.tar.gz
     ln -s ${REL_NAME} "${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION}/bin/rc"
 
     install -m 0755 -d "${D}/${SYSCONFIG_PREFIX}"


### PR DESCRIPTION
current packaging-implementation of elixir-releases (mix/exrm based) adds another unnecessary tar-ball (probably coming from original relx-phase) to the package.

this PR fixes this by removing that exact tar.

please test!
