### PR TITLE
reduce verbosity of caros-service bbclass

### DIFF
--- a/classes/caros-service.bbclass
+++ b/classes/caros-service.bbclass
@@ -10,12 +10,12 @@ python carossrv_populate_packages() {
     postinst = d.getVar('pkg_postinst_%s' % pkg, True)
     if not postinst:
         postinst = '#!/bin/sh\n'
-    postinst += "#!/bin/sh\n# no-op\nsystemctl() {\necho defused: systemctl \"$@\"\n}\n"
+    postinst += "#!/bin/sh\n# no-op\nsystemctl() {\n:\n}\n"
     d.setVar('pkg_postinst_%s'%pkg, postinst)
 
     prerm = d.getVar('pkg_prerm_%s' % pkg, True)
     if not prerm:
         prerm = '#!/bin/sh\n'
-    prerm += "#!/bin/sh\n# no-op\nsystemctl() {\necho defused: systemctl \"$@\"\n}\n"
+    prerm += "#!/bin/sh\n# no-op\nsystemctl() {\n:\n}\n"
     d.setVar('pkg_prerm_%s'%pkg, prerm)
 }


### PR DESCRIPTION
- removed the output "defused: systemctl ..." in opkg hooks
