### PR TITLE
xtables: be graceful without saved state

### DIFF
--- a/recipes-extended/iptables/iptables/xtables-persistence
+++ b/recipes-extended/iptables/iptables/xtables-persistence
@@ -5,21 +5,15 @@ table_families="iptables ip6tables ebtables"
 
 case "$1" in
 	"restore")
-		err=0
 		for iptaf in $table_families; do
 			if [ "$(which ${iptaf}-restore )" ]; then
 				if [ -e /etc/${iptaf}-state ]; then
 					${iptaf}-restore < /etc/${iptaf}-state
 				else
-					echo "no saved ${iptaf} state found."
-					err=1
+					echo "no saved ${iptaf} state found. please run $0 save."
 				fi
 			fi
 		done
-		if [ $err = 1 ]; then
-			echo "please run $0 save"
-			exit 1
-		fi
 	;;
 	"save")
 		for iptaf in $table_families; do
@@ -33,3 +27,4 @@ case "$1" in
 		echo "syntax: $0 {save,restore}"
 	;;
 esac
+exit 0

--- a/recipes-extended/iptables/iptables/xtables-persistence
+++ b/recipes-extended/iptables/iptables/xtables-persistence
@@ -6,9 +6,11 @@ table_families="iptables ip6tables ebtables"
 case "$1" in
 	"restore")
 		for iptaf in $table_families; do
-			if [ "$(which ${iptaf}-restore )" ]; then
+			if type ${iptaf}-restore > /dev/null
+		   	then
 				if [ -e /etc/${iptaf}-state ]; then
 					${iptaf}-restore < /etc/${iptaf}-state
+					echo "restored ${iptaf} state."
 				else
 					echo "no saved ${iptaf} state found. please run $0 save."
 				fi
@@ -17,9 +19,10 @@ case "$1" in
 	;;
 	"save")
 		for iptaf in $table_families; do
-			if [ "$(which ${iptaf}-save )" ]; then
+			if type ${iptaf}-save > /dev/null
+			then
 				${iptaf}-save > /etc/${iptaf}-state
-				echo "saved ${iptaf} state"
+				echo "saved ${iptaf} state."
 			fi
 		done
 	;;


### PR DESCRIPTION
on bootup xtables-persistence tried to restore previous
state and exited with failure if no state was available.
with this change non-existent save-state is accepted
without failure.
