### PR TITLE
replace DESCRIPTION with SUMMARY in mix_class

### DIFF
--- a/classes/mix.bbclass
+++ b/classes/mix.bbclass
@@ -210,6 +210,7 @@ do_install() {
     install -d ${D}${systemd_unitdir}/system/
     install -m 0644 ${MIX_CLASS_FILES}/app-template.service ${D}${systemd_unitdir}/system/${SYSTEMD_UNIT_NAME}.service
     sed -i "s|@@DESCRIPTION@@|${DESCRIPTION}|" ${D}${systemd_unitdir}/system/${SYSTEMD_UNIT_NAME}.service
+    sed -i "s|@@SUMMARY@@|${SUMMARY}|" ${D}${systemd_unitdir}/system/${SYSTEMD_UNIT_NAME}.service
     sed -i "s|@@APPNAME@@|${APPNAME}|" ${D}${systemd_unitdir}/system/${SYSTEMD_UNIT_NAME}.service
     sed -i "s|@@APPVERSION@@|${APPVERSION}|" ${D}${systemd_unitdir}/system/${SYSTEMD_UNIT_NAME}.service
     sed -i "s|@@APP_PREFIX@@|${APP_PREFIX}|" ${D}${systemd_unitdir}/system/${SYSTEMD_UNIT_NAME}.service

--- a/files/mix_class/app-template.service
+++ b/files/mix_class/app-template.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=@@DESCRIPTION@@
+Description=@@SUMMARY@@
 
 [Service]
 SyslogIdentifier=@@APPNAME@@


### PR DESCRIPTION
the "Description" field in the systemd service files is used to create log messages,
if we plainly copy the "DESCRIPTION" from our .bb recipes, the logs won't make much sense
the "SUMMARY" field usually contains a rather short description that works good with
systemd's expactation of a "Description"

if this is accepted we might have to adjust our "SUMMARY"s in the .bb recipes
