### PR TITLE
WIP add zsh/bash to /etc/shells

### DIFF
--- a/recipes-core/base-files/base-files/shells
+++ b/recipes-core/base-files/base-files/shells
@@ -1,0 +1,4 @@
+# /etc/shells: valid login shells
+/bin/sh
+/bin/zsh
+/bin/bash

--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -1,9 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://arp-security.conf \
-           file://etc-environ.d-50-locale"
+           file://etc-environ.d-50-locale \
+           file://shells"
 
-PR := "${PR}.1"
+PR := "${PR}.2"
 
 FILES_${PN} += "50-locale"
 


### PR DESCRIPTION
Add zsh and bash to the available login shells by overwriting the default shells file from poky

WIP because I did not install the package, but it builds and the /etc/shells file is in the correct location in the work directory of the base-files package
