### PR TITLE
[mix-release] set useful permissions

### DIFF
--- a/classes/caros-app-mix.bbclass
+++ b/classes/caros-app-mix.bbclass
@@ -148,4 +148,9 @@ do_install() {
 
         echo "${CONFFILE}" > ${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION}/CONFPATH
     fi;
+
+    # fix permissions
+    chmod 0755 "${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION}/releases/${REL_VSN}/${REL_NAME}.sh"
+    chmod 0755 "${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION}/bin/${REL_NAME}"
+    chmod 0755 "${D}/${APP_PREFIX}/${APPNAME}/${APPVERSION}/bin/nodetool"
 }


### PR DESCRIPTION
- somewhere in the mix-release building process (relx/exrm)
  permissions broke
- this commit fixes the known issues by explicitly setting
  them to 0755 (instead of 0700) for executables
