### PR TITLE
Add override for sshd.socket

### DIFF
--- a/recipes-connectivity/openssh/openssh/etc_systemd_system_sshd.socket.d_override.conf
+++ b/recipes-connectivity/openssh/openssh/etc_systemd_system_sshd.socket.d_override.conf
@@ -1,0 +1,17 @@
+# Use this file to add or override the configuration of the sshd socket. 
+#
+# You can for example define specific IPs to listen to instead of all available addresses
+#
+# Run `systemctl daemon-reload; systemctl restart sshd.socket` to apply changes to this file.
+
+[Socket]
+
+# The empty entry resets the list so we start fresh
+ListenStream=
+
+# Change 0.0.0.0 to the IP you want sshd to bind to.
+# Add more instances to specify several IPs to bind to.
+ListenStream=0.0.0.0:22
+
+# Bind to the addresses even if they are not (yet) available
+FreeBind=true

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,13 @@
+PR := "${PR}.1"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://etc_systemd_system_sshd.socket.d_override.conf"
+
+do_install_append () {
+    install -d ${D}${sysconfdir}/systemd/system/sshd.socket.d
+    install -m 0644 ${WORKDIR}/etc_systemd_system_sshd.socket.d_override.conf ${D}${sysconfdir}/systemd/system/sshd.socket.d/override.conf
+}
+
+FILES_${PN}-sshd += "${sysconfdir}/systemd/system/sshd.socket.d/override.conf"
+CONFFILES_${PN}-sshd += "${sysconfdir}/systemd/system/sshd.socket.d/override.conf"


### PR DESCRIPTION
Adds possibility to bind to specific addresses

```
new file:   recipes-connectivity/openssh/openssh/etc_systemd_system_sshd.socket.d_override.conf
new file:   recipes-connectivity/openssh/openssh_%.bbappend
```
