### PR TITLE
Clarify that IP and port can be configured in sshd override.

### DIFF
--- a/recipes-connectivity/openssh/openssh/etc_systemd_system_sshd.socket.d_override.conf
+++ b/recipes-connectivity/openssh/openssh/etc_systemd_system_sshd.socket.d_override.conf
@@ -1,17 +1,17 @@
-# Use this file to add or override the configuration of the sshd socket. 
+# Use this file to add or override the configuration of sshd.socket.
 #
-# You can for example define specific IPs to listen to instead of all available addresses
+# You can for example define specific IP/port combinations to listen to instead of all available addresses.
 #
 # Run `systemctl daemon-reload; systemctl restart sshd.socket` to apply changes to this file.
 
 [Socket]
 
-# The empty entry resets the list so we start fresh
+# The empty entry resets the list so we start fresh.
 ListenStream=
 
-# Change 0.0.0.0 to the IP you want sshd to bind to.
-# Add more instances to specify several IPs to bind to.
+# Change 0.0.0.0:22 to the IP and port you want sshd to bind to.
+# Add more instances to specify several IP/port combinations.
 ListenStream=0.0.0.0:22
 
-# Bind to the addresses even if they are not (yet) available
+# Bind to the addresses even if they are not (yet) available.
 FreeBind=true


### PR DESCRIPTION
```
modified:   recipes-connectivity/openssh/openssh/etc_systemd_system_sshd.socket.d_override.conf
```
