### PR TITLE
add rofl-common 0.6.1

### DIFF
--- a/recipes-sdn/rofl/rofl-common_0.6.1.bb
+++ b/recipes-sdn/rofl/rofl-common_0.6.1.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=5d425c8f3157dbf212db2ec53d9e5132"
 
 DEPENDS = "libconfig"
 
-SRC_URI = "git://github.com/bisdn/rofl-core.git;branch=master-0.3"
-SRCREV="ec1bd289b23f29e5ba4d1b3a549159eac87b1f32"
+SRC_URI = "git://github.com/bisdn/rofl-common.git;branch=stable-0.6"
+SRCREV="0adb3723fd6cd61686ad2986cffb434ee053a4fe"
 
 PE = "1"
 PR = "r1"
@@ -14,5 +14,7 @@ PR = "r1"
 S = "${WORKDIR}/git"
 
 inherit autotools
+
+DEPENDS += "openssl"
 
 EXTRA_OECONF = "${@base_contains("IMAGE_FEATURES", 'debug-tweaks-rofl', '--enable-debug', '', d)}"


### PR DESCRIPTION
Rofl-core was merged with other components to rofl-common and is obsolete now for more information see:

[rofl-core](https://github.com/bisdn/rofl-core#please-note)
