### PR TITLE
change package split json-spirit

### DIFF
--- a/recipes-support/json-spirit/json-spirit_git.bb
+++ b/recipes-support/json-spirit/json-spirit_git.bb
@@ -8,11 +8,15 @@ SECTION = "console/tools"
 SRC_URI = "git://github.com/sirikata/json-spirit.git"
 SRCREV = "4f1a1023b5d14ec98887ead132d881b8a7acfd3c"
 PV = "git${SRCPV}"
-PR = "r1"
+PR = "r2"
 
 DEPENDS = "boost"
 
 S = "${WORKDIR}/git"
+
+FILES_${PN} = "${libdir} \
+               ${includedir}"
+FILES_${PN}-dev = ""
 
 OECMAKE_SOURCEPATH = "${S}/build"
 


### PR DESCRIPTION
There were wrong files moved to the dev package which results in blocking dependencies, since the dev package has a run dependency on the "normal" package. In this case the "normal" package was empty and not created.

With no json-spirit package present and json-spirit-dev depending on it the installation was blocked.
