### PR TITLE
add missing openvswitch run dependencie

### DIFF
--- a/recipes-networking/openvswitch/openvswitch_git.bbappend
+++ b/recipes-networking/openvswitch/openvswitch_git.bbappend
@@ -1,0 +1,3 @@
+PR := "${PR}.1"
+
+RDEPENDS_${PN}_append = " kernel-module-openvswitch "


### PR DESCRIPTION
In the upstream package the kernel module is missing as run dependence.
