### PR TITLE
[os-release] use double-quotes for PRETTY_NAME

### DIFF
--- a/recipes-core/os-release/os-release.bbappend
+++ b/recipes-core/os-release/os-release.bbappend
@@ -1,4 +1,6 @@
+PR:="${PR}.1"
 HOME_URL="caros.io"
 BUG_REPORT_URL="support@travelping.com"
 
 OS_RELEASE_FIELDS += "HOME_URL BUG_REPORT_URL"
+PRETTY_NAME = '"${DISTRO_NAME} ${VERSION}"'


### PR DESCRIPTION
- using quotes for values with spaces is required
