### PR TITLE
make static routes systemd restart safe

### DIFF
--- a/recipes-networking/static-routes/files/static-routes.sh
+++ b/recipes-networking/static-routes/files/static-routes.sh
@@ -2,5 +2,5 @@
 
 grep -v '^#' $1 | while read LINE
 do
-  eval "ip route add $LINE"
+  eval "ip route replace $LINE"
 done


### PR DESCRIPTION
since adding routes that are already in place on the system will result
in an error I changed the script to use `ip route replace`