### PR TITLE
bump: exometer-influxdb -> 0.5.5

### DIFF
--- a/recipes-erlang/exometer-influxdb/erlang-exometer-influxdb_0.5.5.bb
+++ b/recipes-erlang/exometer-influxdb/erlang-exometer-influxdb_0.5.5.bb
@@ -1,13 +1,13 @@
 SUMMARY = "Exometer InfluxDB reporter"
 SECTION = "devel"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://README.md;md5=b933866ccbb932327446d700f06847fc"
+LIC_FILES_CHKSUM = "file://README.md;md5=800f96d7303a1e2a8ed5d2aec36ee1a7"
 
-PR = "r2"
+PR = "r1"
 
 SRC_URI = "git://github.com/travelping/exometer_influxdb \
 	   file://config.ini"
-SRCREV = "${AUTOREV}"
+SRCREV = "6aa389b5d36d3b0935ab4f77fb65f96e0dd18286"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
adds https support for the influxdb connection