### PR TITLE
[logrotate] use correct path to binary in unit

### DIFF
--- a/recipes-extended/logrotate/logrotate/logrotate.service
+++ b/recipes-extended/logrotate/logrotate/logrotate.service
@@ -3,4 +3,4 @@ Description=logrotate
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/logrotate /etc/logrotate.conf
+ExecStart=/usr/sbin/logrotate /etc/logrotate.conf


### PR DESCRIPTION
systemd service unit is using /usr/bin/logrotate but our binary is in sbin/