### PR TITLE
[bird] change from systemd to caros-service

### DIFF
--- a/recipes-networking/bird/bird_1.6.3.bb
+++ b/recipes-networking/bird/bird_1.6.3.bb
@@ -12,6 +12,8 @@ LIC_FILES_CHKSUM = "file://README;beginline=87;endline=103;md5=0efecc23f03902258
 # the "ip" command from busybox is not sufficient (flush by protocol flushes all routes)
 RDEPENDS_${PN} += "iproute2"
 
+PR = "r1"
+
 #
 # wget < 1.16.2 is broken for passive ftp in some cases,
 # see https://lists.gnu.org/archive/html/bug-wget/2015-01/msg00007.html
@@ -26,7 +28,7 @@ SRC_URI += " file://envvars"
 SRC_URI[md5sum] = "63dd93a7a23c274fc5b7f2e37664bfb7"
 SRC_URI[sha256sum] = "39c51cf57c3ba8b5978b2a657ffa2f647ec7f3ae643e91cf42ee5cb070cf7e7c"
 
-inherit autotools systemd useradd
+inherit autotools caros-service useradd
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "bird.service"


### PR DESCRIPTION
Change from systemd to caros-service so the bird service is not started and enabled by default after an upgrade.